### PR TITLE
More rusty; Add Makefile for easier testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+default: release
+
+.PHONY: all
+
+all: build test
+
+build:
+	cargo build
+
+release:
+	cargo build --release
+
+test:
+	cargo test -- --nocapture
+
+clean:
+	cargo clean


### PR DESCRIPTION
- A little more rusty for test code
- Add Makefile for easier testing

TODO: in the future, we can replace `decode32u` with stuffs in crate `byteorder`.